### PR TITLE
Make BluetoothEvent works with webcomponents

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -515,10 +515,13 @@ function updateDescriptor(chromeDescriptor) {
 // Events:
 
 function BluetoothEvent(type, initDict) {
-  this.type = type;
   initDict = initDict || {};
-  this.bubbles = !!initDict.bubbles;
-  this.cancelable = !!initDict.cancelable;
+  var e = new Event(type, initDict)
+  e.__proto__ = this.__proto__;
+  for (var key in initDict) {
+    e[key] = initDict[key];
+  }
+  return e;
 };
 BluetoothEvent.prototype = {
   __proto__: Event.prototype,


### PR DESCRIPTION
We will need to include `webcomponentsjs` to make the polyfill works on iOS's webview. This change is related to https://github.com/webcomponents/webcomponentsjs/issues/79
